### PR TITLE
Move writeable folders to /media

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ This downloads the app from the Ubuntu app store
 
 `$ sudo snap install transmissionbt --beta --devmode`
 
+*Note: devmode is required because snapd doesn't offer yet the needed interface to confine this snap*
+
+The next step is to connect the Snap to you home and /media folders and to restart the service
+
+```bash
+$ snap connect transmissionbt:home ubuntu-core:home
+$ snap connect transmissionbt:removable-media ubuntu-core:removable-media
+$ sudo systemctl restart snap.transmissionbt.transmission-daemon
+```
+
 You can optionally relax the apparmor policy by typing:
 
 `$ sudo snap connect transmissionbt:mount-observe ubuntu-core:mount-observe`
@@ -83,29 +93,27 @@ You should see a high number of rules.
 
 Place your torrents files here:
 
-`/var/snap/transmissionbt/common/torrents`
-
-*Note: It is advised to symlink this folder to another area of the system with easier access if you're not using the snap on Ubuntu Core*
+`/media/transmissionbt/torrents`
 
 The downloaded files are placed here:
 
-`/var/snap/transmissionbt/common/downloads`
+`/media/transmissionbt/downloads`
 
 Files still being downloaded can be found here:
 
-`/var/snap/transmissionbt/common/incomplete`
+`/media/transmissionbt/incomplete`
 
 ## Creating torrents
 
 Create the torrent
 
 ```
-$ sudo transmissionbt.transmission-create -o ~/torrents/transmissionbt_1.0.1oparoz_amd64.snap.torrent -c "transmissionbt Snap for Ubuntu Snappy" -t udp://tracker.openbittorrent.com:80 -t udp://open.demonii.com:1337 -t udp://tracker.coppersurfer.tk:6969 -t udp://tracker.leechers-paradise.org:6969 ~/sharing/transmissionbt_1.0.1oparoz_amd64.snap
+$ sudo transmissionbt.transmission-create -o ~/torrents/transmissionbt_1.0.1oparoz_amd64.snap.torrent -c "transmissionbt Snap for Ubuntu Snappy" -t udp://tracker.openbittorrent.com:80 -t udp://open.demonii.com:1337 -t udp://tracker.coppersurfer.tk:6969 -t udp://tracker.leechers-paradise.org:6969 ~/mysnaps/transmissionbt_1.0.1oparoz_amd64.snap
 ```
 
 ### Explanations
 
-Torrent to create, including the full path to its location
+Path to the torrent to create, including the full path to its location
 
 `-o ~/torrents/transmissionbt_1.0.1oparoz_amd64.snap.torrent`
 
@@ -124,14 +132,14 @@ As many trackers as you want. Use more than one for redundancy
 
 File or directory to share
 
-`~/sharing/transmissionbt_1.0.1oparoz_amd64.snap`
+`~/mysnaps/transmissionbt_1.0.1oparoz_amd64.snap`
 
 ## Seeding
 
-Copy both the files/folder to your transmission download folder
+Copy the file/folder to your transmission download folder
 
 ```
-$ sudo cp ~/downloads/transmissionbt_1.0.1oparoz_amd64.snap /var/snap/transmissionbt/common/downloads/
+$ sudo cp ~/mysnaps/transmissionbt_1.0.1oparoz_amd64.snap /media/transmissionbt/downloads/
 ```
 
 Send the torrent file to transmission

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: transmissionbt
-version: 1.0.1oparoz
+version: 2.92oparoz3
 summary: Download and share using torrents with transmissionbt
 description: Download and share files using transmissionbt Bittorrent application on Ubuntu Snappy. Has to be run in devmode
 grade: devel
@@ -11,7 +11,7 @@ apps:
     command: transmission-init start
     stop-command: transmission-init stop
     daemon: forking
-    plugs: [network, network-bind, mount-observe]
+    plugs: [network, network-bind, mount-observe, home, removable-media]
 
   # mDNS daemon
   mdns-publisher:

--- a/src/transmission/customizations/transmission-init
+++ b/src/transmission/customizations/transmission-init
@@ -73,8 +73,15 @@ BIN=$SNAP/bin/$NAME
 PIDFILE=$TRANSMISSION_HOME/$NAME.pid
 LOGFILE=$TRANSMISSION_HOME/$NAME.log
 
+RW_TORRENTS=/media/transmissionbt/torrents
+RW_INCOMPLETE=/media/transmissionbt/incomplete
+RW_DOWNLOADS=/media/transmissionbt/downloads
+RW_TORRENTS_OLD=$SNAP_COMMON/torrents
+RW_INCOMPLETE_OLD=$SNAP_COMMON/incomplete
+RW_DOWNLOADS_OLD=$SNAP_COMMON/downloads
+
 # As a daemon
-OPTS="--blocklist --pid-file $PIDFILE --logfile $LOGFILE --download-dir $SNAP_COMMON/downloads --incomplete-dir $SNAP_COMMON/incomplete --watch-dir $SNAP_COMMON/torrents"
+OPTS="--blocklist --pid-file $PIDFILE --logfile $LOGFILE --download-dir $RW_DOWNLOADS --incomplete-dir $RW_INCOMPLETE --watch-dir $RW_TORRENTS"
 
 create_filesystem() {
 	if [ -d $TRANSMISSION_HOME ]; then
@@ -90,14 +97,24 @@ create_filesystem() {
 		#chown :ubuntu $RW_SETTINGS
 	fi
 
-	if [ ! -d $SNAP_COMMON/torrents ]; then
+	# This currently works well because we're unconfined, but it will break in the future and
+	# will require to wait for the user to connect the plugs and slots
+	if [ ! -d $RW_TORRENTS ]; then
 		echo "Creating media folders"
-		mkdir -p -m 770 $SNAP_COMMON/torrents
+		mkdir -p -m 770 $RW_TORRENTS
 		#chown :ubuntu $SNAP_DATA/torrents
-		mkdir -p -m 770 $SNAP_COMMON/downloads
+		mkdir -p -m 770 $RW_DOWNLOADS
 		#chown :ubuntu $SNAP_DATA/downloads
-		mkdir -p -m 770 $SNAP_COMMON/incomplete
+		mkdir -p -m 770 $RW_INCOMPLETE
 		#chown :ubuntu $SNAP_DATA/incomplete
+
+		# Move data from old folders
+		mv $RW_TORRENTS_OLD/* $RW_TORRENTS/
+		mv $RW_INCOMPLETE_OLD/* $RW_INCOMPLETE/
+		mv $RW_DOWNLOADS_OLD/* $RW_DOWNLOADS/
+		rm -rf $RW_TORRENTS_OLD
+		rm -rf $RW_INCOMPLETE_OLD
+		rm -rf $RW_DOWNLOADS_OLD
 	fi
 }
 


### PR DESCRIPTION
This will make it easier for other snaps to manage the torrents and download folders.
The home folder is also available if people want to use it.

Fixes #1 
Fixes #2 
